### PR TITLE
fix: dataIni invalid key access, routes imports and list-files not found

### DIFF
--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -13,14 +13,14 @@ const Client = {
     this.data_ini = path.join(__dirname, '..', '..', configs.CLIENT_RESPATH, configs.CLIENT_DATAINI);
 
     if (!fs.existsSync(this.data_ini)) {
-      // console.error('DATA.INI file not found:', this.data_ini);
+      console.error('DATA.INI file not found:', this.data_ini);
       return;
     }
 
     const dataIniContent = fs.readFileSync(this.data_ini, 'utf-8');
     const dataIni = parseIni(dataIniContent);
     this.grfs = await Promise.all(
-      dataIni.Data.map(async grfPath => {
+      dataIni.data.map(async grfPath => {
         const grf = new Grf(path.join(__dirname, '..', '..', configs.CLIENT_RESPATH, grfPath));
         await grf.load();
         return grf;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const path = require('path');
-const fs = require('fs);
+const fs = require('fs');
 const router = express.Router();
 const Client = require('../controllers/clientController');
 const configs = require('../config/configs');
@@ -21,6 +21,12 @@ router.post('/search', (req, res) => {
   res.send(files.join('\n'));
 });
 
+// Nova rota para listar arquivos
+router.get('/list-files', async (req, res) => {
+  const files = Client.listFiles();
+  res.json(files);
+});
+
 router.get('/*', async (req, res) => {
   const filePath = req.params[0];
 
@@ -37,12 +43,6 @@ router.get('/*', async (req, res) => {
 
   res.type(path.extname(filePath));
   res.send(fileContent);
-});
-
-// Nova rota para listar arquivos
-router.get('/list-files', async (req, res) => {
-  const files = Client.listFiles();
-  res.json(files);
 });
 
 module.exports = router;


### PR DESCRIPTION
When testing this I had a couple issues.

One of them was:
```
TypeError: Cannot read properties of undefined (reading 'map')
    at Object.init (/Users/guicaulada/Work/Personal/Projects/roBrowserLegacy-RemoteClient-JS/src/controllers/clientController.js:23:20)
    at /Users/guicaulada/Work/Personal/Projects/roBrowserLegacy-RemoteClient-JS/src/routes/index.js:10:16
    at Object.<anonymous> (/Users/guicaulada/Work/Personal/Projects/roBrowserLegacy-RemoteClient-JS/src/routes/index.js:11:3)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Module.require (node:internal/modules/cjs/loader:1235:19)
    at require (node:internal/modules/helpers:176:18)
    at Object.<anonymous> (/Users/guicaulada/Work/Personal/Projects/roBrowserLegacy-RemoteClient-JS/index.js:6:16)
```

Which is caused by accessing `dataIni.Data` instead of `dataIni.data` as is returned from the `parseIni` function.

The second issue was the routes file was missing a `'` on the `fs` import, and the `list-files` route was created after the `/*` resulting in a `File not found` instead of a files list.