### PR TITLE
Improve logging

### DIFF
--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -61,7 +61,7 @@ const Client = {
       }
     }
 
-		console.error(`File not found: ${grfFilePath}`);
+    console.error(`File not found: ${grfFilePath}`);
     return null;
   },
 

--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -35,6 +35,7 @@ const Client = {
 
     // Verificar se o arquivo já existe na pasta de dados
     if (fs.existsSync(localPath)) {
+      console.error(`File found on folder: ${grfFilePath}`);
       return fs.readFileSync(localPath);
     }
 
@@ -51,6 +52,8 @@ const Client = {
             }
             fs.writeFileSync(localPath, fileContent);
           }
+          
+          console.error(`File found on ${grf.fileName}: ${grfFilePath}`);
           return fileContent;
         }
       } else {
@@ -58,6 +61,7 @@ const Client = {
       }
     }
 
+		console.error(`File not found: ${grfFilePath}`);
     return null;
   },
 

--- a/src/controllers/grfController.js
+++ b/src/controllers/grfController.js
@@ -1,8 +1,9 @@
 const { GrfNode } = require("@chicowall/grf-loader");
 const fs = require("fs");
-
+const path = require("path");
 class Grf {
 	constructor(filePath) {
+		this.fileName = path.basename(filePath);
 		this.filePath = filePath;
 		this.grf = null;
 		this.loaded = false;
@@ -32,7 +33,6 @@ class Grf {
 		try {
 			const { data, error } = await this.grf.getFile(filename);
 			if (error) {
-				console.error(`Error getting file from GRF: ${error}`);
 				return null;
 			}
 			return Buffer.from(data);


### PR DESCRIPTION
While working with this I noticed logging was very verbose at times, making it difficult to debug if files were being found or not, with these changes we make it less verbose by not logging every GRF where the file wasn't found.

If the file is found in a GRF or in the extracted folders it logs where the file was found.

After checking all GRFs and extracted files it logs that the file wasn't found.