### PR TITLE
Normalize Data section name in INI parser

### DIFF
--- a/src/controllers/clientController.js
+++ b/src/controllers/clientController.js
@@ -22,7 +22,7 @@ const Client = {
 
     // Check if data section exists and has GRF files configured
     if (!dataIni.data || dataIni.data.length === 0) {
-      console.log('No GRF files configured in DATA.INI. Add GRF files to [Data] section.');
+      console.log('No GRF files configured in DATA.INI. Add GRF files to [data] section.');
       this.grfs = [];
       return;
     }
@@ -144,6 +144,10 @@ function parseIni(data) {
     } else if (regex.section.test(line)) {
       const match = line.match(regex.section);
       section = match[1];
+      // Normalizar seção "Data" para lowercase
+      if (section.toLowerCase() === 'data') {
+        section = 'data';
+      }
       if (!value[section]) {
         value[section] = [];
       }


### PR DESCRIPTION
- Modificar função parseIni para converter seção "Data" para lowercase ("data")
- Atualizar mensagem de log para usar nome normalizado [data]
- Garantir compatibilidade com qualquer variação de case (Data, DATA, data, DaTa)

Motivo: O cliente JS é case-sensitive e só funciona com um nome específico de seção, enquanto alguns clientes aceitam qualquer variação.