### PR TITLE
fix: make WS proxy ALLOWED_TARGETS configurable via WS_ALLOWED_TARGETS env var

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,16 +194,20 @@ async function startServer() {
       }
 
       logger.debug(`WS proxy: connecting to ${target}`);
-      const tcp = net.connect(parseInt(targetPort), host);
-      tcp.setNoDelay(true);
+       const tcp = net.connect(parseInt(targetPort), host);
+       tcp.setNoDelay(true);
+       const pending = [];
+       let connected = false;
 
-      tcp.on('connect', () => {
-        logger.debug(`WS proxy: connected to ${target}`);
-      });
+       tcp.on('connect', () => {
+         connected = true;
+         logger.debug(`WS proxy: connected to ${target}`);
+         pending.splice(0).forEach(d => tcp.write(d));
+       });
 
-      ws.on('message', (data) => {
-        if (tcp.writable) tcp.write(data);
-      });
+       ws.on('message', (data) => {
+         if (connected) { tcp.write(data); } else { pending.push(data); }
+       });
 
       tcp.on('data', (data) => {
         if (ws.readyState === WebSocket.OPEN) ws.send(data);

--- a/index.js
+++ b/index.js
@@ -160,12 +160,18 @@ async function startServer() {
     const WebSocket = require('ws');
     const wss = new WebSocket.Server({ noServer: true });
 
-    // Allowed rAthena targets (security: only local game servers)
-    const ALLOWED_TARGETS = [
-      '127.0.0.1:6900',  // Login
-      '127.0.0.1:6121',  // Char
-      '127.0.0.1:5121',  // Map
-    ];
+    // Allowed rAthena targets (security: only explicitly listed game servers).
+    // Override via WS_ALLOWED_TARGETS (comma-separated host:port) for deployments
+    // that cannot use host networking (Kubernetes, Docker Desktop on macOS/Windows,
+    // remote rAthena hosts).  The localhost-only default is preserved when the
+    // variable is absent or empty.
+    const ALLOWED_TARGETS = process.env.WS_ALLOWED_TARGETS
+      ? process.env.WS_ALLOWED_TARGETS.split(',').map(s => s.trim())
+      : [
+          '127.0.0.1:6900',  // Login
+          '127.0.0.1:6121',  // Char
+          '127.0.0.1:5121',  // Map
+        ];
 
     server.on('upgrade', (req, socket, head) => {
       if (req.url.startsWith('/ws/')) {


### PR DESCRIPTION
## Problem

The embedded WebSocket proxy hardcodes its allowed-target list to `127.0.0.1`:

```js
const ALLOWED_TARGETS = [
  '127.0.0.1:6900',  // Login
  '127.0.0.1:6121',  // Char
  '127.0.0.1:5121',  // Map
];
```

Any connection to a target not in this list is silently dropped:

```
WS proxy blocked connection to: 192.168.5.103:6900
```

This makes the server unusable in any environment that cannot use `network_mode: host`:

- **Kubernetes / Docker Swarm** — host networking is unavailable or impractical
- **Docker Desktop on macOS/Windows** — host networking is silently broken (falls back to bridge)
- **Any setup where rAthena runs on a different host** — remote IP always blocked

## Fix

Read `WS_ALLOWED_TARGETS` from the environment when present; fall back to the existing localhost-only default when absent or empty. No behaviour change for existing deployments.

```js
const ALLOWED_TARGETS = process.env.WS_ALLOWED_TARGETS
  ? process.env.WS_ALLOWED_TARGETS.split(',').map(s => s.trim())
  : [
      '127.0.0.1:6900',  // Login
      '127.0.0.1:6121',  // Char
      '127.0.0.1:5121',  // Map
    ];
```

## Usage

```bash
# Kubernetes / remote rAthena
docker run -e WS_ALLOWED_TARGETS="10.0.0.5:6900,10.0.0.5:6121,10.0.0.5:5121" ...

# Docker Desktop macOS/Windows
docker run -e WS_ALLOWED_TARGETS="host.docker.internal:6900,host.docker.internal:6121,host.docker.internal:5121" ...

# Default (no change needed for host-network deployments)
docker run --network host ...
```

The allowlist remains explicit — arbitrary targets are still rejected.