### PR TITLE
fix: WS proxy - configurable targets, TCP connect race condition, robustness improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,12 @@ CACHE_WARM_UP_LIMIT=500
 ENABLE_WSPROXY=true
 ENABLE_STATIC_SERVE=true
 ROBROWSER_PATH=../roBrowserLegacy
+
+# WS proxy target allowlist (only used when ENABLE_WSPROXY=true)
+# Comma-separated "host:port" pairs the proxy is permitted to forward to.
+# Defaults to localhost only (127.0.0.1:6900, 6121, 5121) when not set.
+# Override for non-host-network deployments where rAthena is on a different host:
+#   WS_ALLOWED_TARGETS=10.0.0.5:6900,10.0.0.5:6121,10.0.0.5:5121
+# Docker Desktop (macOS/Windows):
+#   WS_ALLOWED_TARGETS=host.docker.internal:6900,host.docker.internal:6121,host.docker.internal:5121
+#WS_ALLOWED_TARGETS=

--- a/index.js
+++ b/index.js
@@ -160,12 +160,18 @@ async function startServer() {
     const WebSocket = require('ws');
     const wss = new WebSocket.Server({ noServer: true });
 
-    // Allowed rAthena targets (security: only local game servers)
-    const ALLOWED_TARGETS = [
-      '127.0.0.1:6900',  // Login
-      '127.0.0.1:6121',  // Char
-      '127.0.0.1:5121',  // Map
-    ];
+    // Allowed rAthena targets (security: only explicitly listed game servers).
+    // Override via WS_ALLOWED_TARGETS (comma-separated host:port) for deployments
+    // that cannot use host networking (Kubernetes, Docker Desktop on macOS/Windows,
+    // remote rAthena hosts).  The localhost-only default is preserved when the
+    // variable is absent or empty.
+    const ALLOWED_TARGETS = process.env.WS_ALLOWED_TARGETS
+      ? process.env.WS_ALLOWED_TARGETS.split(',').map(s => s.trim())
+      : [
+          '127.0.0.1:6900',  // Login
+          '127.0.0.1:6121',  // Char
+          '127.0.0.1:5121',  // Map
+        ];
 
     server.on('upgrade', (req, socket, head) => {
       if (req.url.startsWith('/ws/')) {
@@ -178,41 +184,81 @@ async function startServer() {
     });
 
     wss.on('connection', (ws, req) => {
-      const target = req.url.replace('/ws/', '');
-      const [host, targetPort] = target.split(':');
+      // Strip the /ws/ prefix to get "host:port"
+      // Use slice (not replace) so a misconfigured socketProxy with no /ws path
+      // produces an obviously-invalid target rather than a partial match.
+      const target = req.url.slice('/ws/'.length);
 
-      if (!ALLOWED_TARGETS.includes(target)) {
-        logger.warn(`WS proxy blocked connection to: ${target}`);
+      // Validate target format before allowlist check
+      const colonIdx = target.lastIndexOf(':');
+      const host = colonIdx !== -1 ? target.slice(0, colonIdx) : '';
+      const targetPort = colonIdx !== -1 ? parseInt(target.slice(colonIdx + 1), 10) : NaN;
+
+      if (!host || !Number.isInteger(targetPort) || targetPort < 1 || targetPort > 65535) {
+        logger.warn(`WS proxy rejected malformed target: "${target}"`);
         ws.close();
         return;
       }
 
-      logger.debug(`WS proxy: connecting to ${target}`);
-      const tcp = net.connect(parseInt(targetPort), host);
+      logger.info(`WS attempt: ${target}`);
+
+      if (!ALLOWED_TARGETS.includes(target)) {
+        logger.warn(`WS proxy blocked: ${target} (allowed: ${ALLOWED_TARGETS.join(', ')})`);
+        ws.close();
+        return;
+      }
+
+      logger.info(`WS proxy: connecting to ${target}`);
+      const tcp = net.connect(targetPort, host);
       tcp.setNoDelay(true);
 
+      // Buffer messages received before the TCP connection is established.
+      // roBrowser sends the first game packet synchronously in its onopen handler,
+      // which races with net.connect()'s async 'connect' event. Without buffering,
+      // packets arriving before 'connect' fires are silently dropped.
+      const MAX_PENDING = 64;
+      const pending = [];
+      let connected = false;
+
+      // Single cleanup guard: ensures tcp and ws are torn down exactly once
+      // regardless of which side closes first or whether an error occurs.
+      // Prevents double tcp.end() and misleading "client closed" log on errors.
+      let cleaned = false;
+      const cleanup = (reason) => {
+        if (cleaned) return;
+        cleaned = true;
+        logger.info(`WS proxy: closed ${target} (${reason})`);
+        if (!tcp.destroyed) tcp.destroy();
+        if (ws.readyState === WebSocket.OPEN) ws.close();
+      };
+
       tcp.on('connect', () => {
-        logger.debug(`WS proxy: connected to ${target}`);
+        connected = true;
+        logger.info(`WS proxy: connected  to ${target}`);
+        pending.splice(0).forEach(d => tcp.write(d));
       });
 
       ws.on('message', (data) => {
-        if (tcp.writable) tcp.write(data);
+        if (connected) {
+          tcp.write(data);
+        } else if (pending.length < MAX_PENDING) {
+          pending.push(data);
+        } else {
+          logger.warn(`WS proxy: pending queue full for ${target}, dropping message`);
+        }
       });
 
       tcp.on('data', (data) => {
         if (ws.readyState === WebSocket.OPEN) ws.send(data);
       });
 
-      ws.on('close', () => tcp.end());
-      ws.on('error', () => tcp.end());
-      tcp.on('close', () => { if (ws.readyState === WebSocket.OPEN) ws.close(); });
-      tcp.on('error', (err) => {
-        logger.error(`WS proxy TCP error (${target}):`, err.message);
-        if (ws.readyState === WebSocket.OPEN) ws.close();
-      });
+      ws.on('close', () => cleanup('client closed'));
+      ws.on('error', (err) => cleanup(`client error: ${err.message}`));
+      tcp.on('close', () => cleanup('server closed'));
+      tcp.on('error', (err) => cleanup(`server error: ${err.message}`));
     });
 
-    logger.debug(`WebSocket proxy enabled on /ws/ (allowed: ${ALLOWED_TARGETS.join(', ')})`);
+    logger.info(`WebSocket proxy enabled on /ws/ (allowed: ${ALLOWED_TARGETS.join(', ')})`);
   }
 
   server.listen(port, async () => {

--- a/src/validators/startupValidator.js
+++ b/src/validators/startupValidator.js
@@ -864,6 +864,35 @@ class StartupValidator {
       this.addWarning(".env file not found! Copy .env.example to .env and configure it");
     }
 
+    // Validate WS_ALLOWED_TARGETS when the proxy is enabled
+    const wsProxyEnabled = process.env.ENABLE_WSPROXY === 'true';
+    const wsAllowedRaw = process.env.WS_ALLOWED_TARGETS || '';
+    if (wsProxyEnabled) {
+      if (wsAllowedRaw) {
+        const entries = wsAllowedRaw.split(',').map(s => s.trim()).filter(Boolean);
+        const invalid = entries.filter(entry => {
+          const colonIdx = entry.lastIndexOf(':');
+          if (colonIdx === -1) return true;
+          const port = parseInt(entry.slice(colonIdx + 1), 10);
+          const host = entry.slice(0, colonIdx);
+          return !host || !Number.isInteger(port) || port < 1 || port > 65535;
+        });
+        if (invalid.length > 0) {
+          this.addError(
+            `WS_ALLOWED_TARGETS contains invalid entries: ${invalid.join(', ')}\n` +
+            `  Each entry must be "host:port" where port is 1-65535.`
+          );
+          hasErrors = true;
+        } else {
+          this.addInfo(`WS_ALLOWED_TARGETS: ${entries.join(', ')}`);
+        }
+        results.WS_ALLOWED_TARGETS = { defined: true, entries };
+      } else {
+        this.addInfo('WS_ALLOWED_TARGETS: not set, using localhost defaults (127.0.0.1:6900/6121/5121)');
+        results.WS_ALLOWED_TARGETS = { defined: false, usingDefaults: true };
+      }
+    }
+
     this.validationResults.env = { valid: !hasErrors, variables: results };
     return !hasErrors;
   }


### PR DESCRIPTION
## Context

This project is listed in the [roBrowserLegacy documentation](https://github.com/MrAntares/roBrowserLegacy/blob/master/doc/README.md) as the recommended JS remote client. There is an open PR ([MrAntares/roBrowserLegacy#956](https://github.com/MrAntares/roBrowserLegacy/pull/956)) adding Docker/K8s deployment support that depends on this project. During that work, three issues were found and fixed in the embedded WS proxy.

**This PR should be merged before MrAntares/roBrowserLegacy#956 is merged**, so the Dockerfile can pin to a commit that includes these fixes.

---

## Problems fixed

### 1. `ALLOWED_TARGETS` hardcoded to `127.0.0.1` — breaks all non-host-network deployments

```js
// Before: only localhost targets work
const ALLOWED_TARGETS = [
  '127.0.0.1:6900',
  '127.0.0.1:6121',
  '127.0.0.1:5121',
];
```

Any deployment where rAthena is not on localhost is silently blocked:
- Kubernetes / Docker Swarm (host networking unavailable)
- Docker Desktop on macOS/Windows (host networking silently broken)
- Any setup where rAthena runs on a different host

**Fix:** Read `WS_ALLOWED_TARGETS` from the environment when set; fall back to the localhost-only default when absent. No behaviour change for existing deployments.

```js
const ALLOWED_TARGETS = process.env.WS_ALLOWED_TARGETS
  ? process.env.WS_ALLOWED_TARGETS.split(',').map(s => s.trim())
  : ['127.0.0.1:6900', '127.0.0.1:6121', '127.0.0.1:5121'];
```

### 2. TCP connect race condition — intermittent silent packet drop

`net.connect()` is async. roBrowser sends the first game packet synchronously in its WebSocket `onopen` handler, which races with the TCP `connect` event. When the browser wins the race, `tcp.writable` is `false` and the packet is silently dropped — causing intermittent disconnects at server/char/map select that are impossible to diagnose from logs.

**Fix:** Buffer incoming messages until TCP connect fires, then flush.

### 3. Multiple robustness improvements

- **URL parsing:** `req.url.replace('/ws/', '')` replaced with `slice` + explicit `host:port` format validation — malformed targets are rejected with a clear warning rather than silently failing the allowlist lookup
- **Cleanup guard:** Single `cleanup(reason)` function replaces four separate close/error handlers — prevents double `tcp.destroy()`, eliminates misleading "client closed" log on error-triggered closes, makes all four close/error paths symmetric and logged
- **Pending queue cap:** Buffered pre-connect messages capped at 64
- **Startup validation:** `WS_ALLOWED_TARGETS` format validated at startup via `validateEnvironment()` — malformed entries caught before any connection is attempted
- **`.env.example`:** Documents `WS_ALLOWED_TARGETS` with examples for Kubernetes, Docker Desktop (macOS/Windows), and the localhost default
- **Improved logging:** Connection lifecycle events (attempt, connect, close, error) promoted to `info` level and visible without debug mode; close reason always logged

---

## Why these issues existed

The proxy was written assuming local deployment (same host as rAthena), where `127.0.0.1` is always correct and the TCP connect completes in <1ms so the race is never hit. These issues only surface in containerised or remote deployments.

---

## Testing

Validated end-to-end in a Kubernetes deployment (Talos Linux) with rAthena on a separate host:
- Login, char select, and map entry all work reliably after the race condition fix
- `WS_ALLOWED_TARGETS` correctly routes connections to the remote rAthena server
- Startup logs show the resolved allowlist and per-connection lifecycle events
- Malformed `WS_ALLOWED_TARGETS` values are caught and reported at startup